### PR TITLE
Fix counts not resetting in fisher

### DIFF
--- a/sources/fisher.c
+++ b/sources/fisher.c
@@ -329,6 +329,7 @@ int main(void){
 	hook=0;
 	hooknum=HOOKS;
 	score=0;
+	memset(count,0,10*sizeof(unsigned int) );
 	while(1){
 		draw();
 		refresh();


### PR DESCRIPTION
The displayed fish counts were not resetting when beginning a new attempt.