### PR TITLE
Write to temp first

### DIFF
--- a/common.h
+++ b/common.h
@@ -20,6 +20,7 @@ You should have received a copy of the CC0 Public Domain Dedication along with t
 #include "config.h"
 #define FOPEN_FAIL -10
 #define ENV_VAR_OR_USERNAME (getenv("NB_PLAYER")?getenv("NB_PLAYER"):getenv("USER"))
+#define MAXPATHSIZE 1000
 FILE* score_file;
 byte score_write(const char* path, long wscore, byte save_to_num){// only saves the top 10, returns the place in the chart
 	score_file=fopen(path,"r");
@@ -36,6 +37,9 @@ byte score_write(const char* path, long wscore, byte save_to_num){// only saves 
 	#endif
 	char name_buff[save_to_num_][60];
 	long score_buff[save_to_num_];
+    char tmp_path[MAXPATHSIZE + 8] = {0};
+    strcpy(tmp_path, path);
+    strcat(tmp_path, ".XXXXXX");
 
 	memset(name_buff,0,save_to_num_*60*sizeof(char) );
 	memset(score_buff,0,save_to_num_*sizeof(long) );
@@ -52,8 +56,8 @@ byte score_write(const char* path, long wscore, byte save_to_num){// only saves 
 		memset(scanned_name,0,60);
 		scanned_score=0;
 	}
-	score_file = fopen(path,"w+") ;//will get  rid of the previous text
-	if(!score_file){
+    FILE* tmp_score_file = fdopen(mkstemp(tmp_path), "w");
+	if(!tmp_score_file){
 		return FOPEN_FAIL;
 	}
 	byte scores_count=location;//if 5 scores were scanned, it is 5. the number of scores it reached
@@ -62,32 +66,41 @@ byte score_write(const char* path, long wscore, byte save_to_num){// only saves 
 
 	for(byte i=0;i<=scores_count && i<save_to_num_-wrote_it;++i){
 		if(!wrote_it && (i>=scores_count || wscore>=score_buff[i]) ){
-			fprintf(score_file,"%s : %ld\n",ENV_VAR_OR_USERNAME,wscore);
+			fprintf(tmp_score_file,"%s : %ld\n",ENV_VAR_OR_USERNAME,wscore);
 			ret=i;
 			wrote_it=1;
 		}
 		if(i<save_to_num_-wrote_it && i<scores_count){
-			fprintf(score_file,"%s : %ld\n",name_buff[i],score_buff[i]);
+			fprintf(tmp_score_file,"%s : %ld\n",name_buff[i],score_buff[i]);
 		}
 	}
-	fflush(score_file);
+	fflush(tmp_score_file);
+    fclose(score_file);
+    if (rename(tmp_path, path) < 0) {
+        return FOPEN_FAIL;
+    }
+    fclose(tmp_score_file);
+    score_file=fopen(path,"r");
+    if (!score_file) {
+        return FOPEN_FAIL;
+    }
 	return ret;
 }
 
 byte fallback_to_home(const char* name,long wscore,byte save_to_num){// only saves the top 10, returns the place in the chart
 	byte ret;
-	char full_path[1000]={0};
+	char full_path[MAXPATHSIZE]={0};
 	if(getenv("NB_SCORES_DIR")){
-		snprintf(full_path,1000,"%s/%s",getenv("NB_SCORES_DIR"),name);
+		snprintf(full_path,MAXPATHSIZE,"%s/%s",getenv("NB_SCORES_DIR"),name);
 		ret=score_write(full_path,wscore,save_to_num);
 		if(ret==FOPEN_FAIL){
 			return ret;//do not fallback this
 		}
 	}
-	snprintf(full_path,1000,"%s/%s",SCORES_DIR,name);
+	snprintf(full_path,MAXPATHSIZE,"%s/%s",SCORES_DIR,name);
 	ret=score_write(full_path,wscore,save_to_num);
 	if(ret==FOPEN_FAIL){
-		snprintf(full_path,1000,"%s/.%s",getenv("HOME"),name);
+		snprintf(full_path,MAXPATHSIZE,"%s/.%s",getenv("HOME"),name);
 		ret=score_write(full_path,wscore,save_to_num);
 	}
 	return ret;

--- a/mines.c
+++ b/mines.c
@@ -29,7 +29,7 @@ int untouched;
 int mscount;
 chtype colors[6]={0};
 int beginy,view_len;
-byte setup_scroll(){
+void setup_scroll(){
 	beginy=0;
 	if(0<py+3-(LINES-EMPTY_LINES)){
 		beginy=py+3-(LINES-EMPTY_LINES);

--- a/nbsdgames.c
+++ b/nbsdgames.c
@@ -134,7 +134,7 @@ void green_border(void){
 }
 
 
-int show_scores(FILE* score_file){
+void show_scores(FILE* score_file){
 	erase();
 	filled_rect(0,0,LINES,COLS);
 	green_border();

--- a/redsquare.c
+++ b/redsquare.c
@@ -41,7 +41,7 @@ void logo(void){
 }
 
 int beginy,view_len;
-byte setup_scroll(){
+void setup_scroll(){
 	beginy=0;
 	if(0<py+3-(LINES-EMPTY_LINES)){
 		beginy=py+3-(LINES-EMPTY_LINES);

--- a/sjump.c
+++ b/sjump.c
@@ -104,7 +104,7 @@ byte save_score(void){
 
 void show_scores(byte playerrank){
 	erase();
-	logo(0,0);
+	logo();
 	if(playerrank==FOPEN_FAIL){
 		mvaddstr(3,0,"Could not open score file");
 		printw("\nHowever, your score is %ld.",score);
@@ -149,7 +149,7 @@ void show_scores(byte playerrank){
 			nocbreak();
 			cbreak();
 			erase();
-			logo(0,0);
+			logo();
 		}
 	}
 	//scorefile is still open with w+

--- a/trsr.c
+++ b/trsr.c
@@ -33,7 +33,7 @@ char sides[2]={'h','h'};
 chtype colors[6]={0};
 int beginy,view_len;
 int turn=0;
-byte setup_scroll(){
+void setup_scroll(){
 	beginy=0;
 	if(0<py+3-(LINES-EMPTY_LINES)){
 		beginy=py+3-(LINES-EMPTY_LINES);


### PR DESCRIPTION
First commit is correcting some warnings clang was complaining about.  The other I think might be a solution to your issue where the scores get wiped on a full partition or when the machine shuts down during writing of scores.  Basically the strategy is write to a temp file, then rename it over the scores file afterward.