### PR TITLE
Fix strict-prototypes warnings

### DIFF
--- a/darrt.c
+++ b/darrt.c
@@ -74,7 +74,7 @@ void red_border(void){
 		
 }
 
-void fill_aims(){
+void fill_aims(void){
 	for(byte i=0;i<26;++i){
 		aims[i].y= randint(8,HLEN);
 		aims[i].x= randint(0,HWID);
@@ -198,7 +198,7 @@ void star_line(byte y){
 	for(byte x=1;x<WID-1;++x)
 		mvaddch(y,x,'.');
 }
-void make_background(){
+void make_background(void){
 	float d;
 	for(byte y=0;y<LEN;++y){
 		for(byte x=0;x<WID;++x){
@@ -228,13 +228,13 @@ void draw_aim(aim a){
 		color=colors[2];
 	mvaddch((int) a.y,(int)a.x,a.sign|color);
 }
-void logo(){
+void logo(void){
 	mvaddstr(0,0," _        ");
 	mvaddstr(1,0,"| '.      ");
 	mvaddstr(2,0,"|  :      ");
         mvaddstr(3,0,"|.' ARRT  ");
 }
-void draw(){
+void draw(void){
 	for(byte y=0;y<LEN;++y){
 		for(byte x=0;x<WID;++x){
 			mvaddch(y,x,background[y][x]);
@@ -256,7 +256,7 @@ void draw(){
 	}
 }
 
-void end_scene(){
+void end_scene(void){
 	for(byte y=0;y<LEN;++y){
 		for(byte x=0;x<WID;++x){
 			mvaddch(y,x,background[y][x]);

--- a/mines.c
+++ b/mines.c
@@ -29,7 +29,7 @@ int untouched;
 int mscount;
 chtype colors[6]={0};
 int beginy,view_len;
-void setup_scroll(){
+void setup_scroll(void){
 	beginy=0;
 	if(0<py+3-(LINES-EMPTY_LINES)){
 		beginy=py+3-(LINES-EMPTY_LINES);

--- a/nbsdgames.c
+++ b/nbsdgames.c
@@ -108,7 +108,7 @@ char help_page[]={
 char choice_str[100]={0};
 char name[100]={0};
 
-void fancy_background(){
+void fancy_background(void){
 	int y,x;
 	int lines=LINES,cols=COLS;
 	for(y=0;y<lines;++y){
@@ -286,7 +286,7 @@ int menu(char* entries,char* title){
 	}
 	goto Refresh;
 }
-void enter_name(){
+void enter_name(void){
 	snprintf(name,25,"%s",getenv("USER"));
 	int input=0;
 	int index=strlen(name);
@@ -315,7 +315,7 @@ void enter_name(){
 	}
 	setenv("NB_PLAYER",name,1);
 }
-void scores(){
+void scores(void){
 	int choice;
 	char address[1000]={0};
 	FILE* score_file;

--- a/pipes.c
+++ b/pipes.c
@@ -294,7 +294,7 @@ void help(void){
 	erase();
 	gameplay();
 }
-int avoid_accidental_pass(){
+int avoid_accidental_pass(void){
 	int input;
 	Again:
 	input=getch();

--- a/redsquare.c
+++ b/redsquare.c
@@ -46,7 +46,7 @@ void logo(void){
 	addstr("| \\ED_)QUARE\n");
 }
 
-int avoid_accidental_pass(){
+int avoid_accidental_pass(void){
 	int input;
 	Again:
 	input=getch();
@@ -148,7 +148,7 @@ void show_scores(byte playerrank){
 
 
 int beginy,view_len;
-void setup_scroll(){
+void setup_scroll(void){
 	beginy=0;
 	if(0<py+3-(LINES-EMPTY_LINES)){
 		beginy=py+3-(LINES-EMPTY_LINES);

--- a/scissor.c
+++ b/scissor.c
@@ -74,7 +74,7 @@ void add_random_angle(item *a){
 	a->vx=cos(a->angle);
 }
 
-void fill_items(){
+void fill_items(void){
 	item *a=NULL;
 	for(byte i=0;i<ITEMS_COUNT;++i){
 		a=items+i;
@@ -160,7 +160,7 @@ void swap_items(item *a, item *b){
 	*a=*b;
 	*b=s;
 }
-void sort_items(){
+void sort_items(void){
 	byte pos=0;//sort for y
 	while(pos<ITEMS_COUNT){
 		if(pos==0 || items[pos].y > items[pos-1].y || ((int) items[pos].y == (int) items[pos-1].y) && (items[pos].x > items[pos-1].x)){
@@ -269,7 +269,7 @@ void collide(item *a, item *b){
 		}
 	}
 }
-void collisions(){
+void collisions(void){
 	item *a,*b;
 	for(byte i=0;i<ITEMS_COUNT;++i){
 		a=&items[i];
@@ -287,7 +287,7 @@ void collisions(){
 	}
 
 }
-void mechanics(){
+void mechanics(void){
 	collisions();
 	static byte slow_motion=0;
 	slow_motion=(slow_motion+1)%1;
@@ -325,7 +325,7 @@ void draw_item(item a){
 	}
 	mvaddch((int) a.y,(int)a.x,shape);
 }
-void find_scissor(){
+void find_scissor(void){
 	item *a=NULL;
 	item *make_player=NULL;
 	for(byte i=0;i<ITEMS_COUNT;++i){
@@ -341,14 +341,14 @@ void find_scissor(){
 		make_player->player=1;
 	}
 }
-void logo(){
+void logo(void){
 	mvaddstr(0,0,"         ");
 	mvaddstr(1,0," _      ");
 	mvaddstr(2,0,"(_'      ");
         mvaddstr(3,0,"._)CISSOR");
 }
 
-void draw(){
+void draw(void){
 	logo();
 	mvprintw(5,0,"Score: %ld",score);
 	for(byte i=0;i<ITEMS_COUNT;++i){
@@ -441,7 +441,7 @@ void sigint_handler(int x){
 	puts("Quit.");
 	exit(x);
 }
-int avoid_accidental_pass(){
+int avoid_accidental_pass(void){
 	int input;
 	Again:
 	input=getch();

--- a/sjump.c
+++ b/sjump.c
@@ -90,7 +90,7 @@ void star_line(byte y){
 	for(byte x=1;x<WID-1;++x)
 		mvaddch(y,x,'.');
 }
-void logo(){
+void logo(void){
 	mvprintw(0,0," _        ___  ");
 	mvprintw(1,0,"(_'        |     Score: %ld",score);
 	mvprintw(2,0,"._)QUARE (_:UMP  Combo: %d",combo);
@@ -184,7 +184,7 @@ void draw_square(byte sy,byte sx){
 	mvaddch(sy+SIZE,sx,ACS_LLCORNER);
 	mvaddch(sy,sx+SIZE*2,ACS_URCORNER);
 }
-void move_o(){
+void move_o(void){
 	if(ox==0){
 		if(oy==0){
 			ox++;
@@ -241,7 +241,7 @@ void draw(int sy,int sx){
 	logo();
 }
 
-byte shooting_scene(){
+byte shooting_scene(void){
 	float dy=(oy-(SIZE/2))/(float)SIZE;
 	float dx=(ox-(SIZE))/(float)(SIZE*2);
 	dy/=2;//it was too hard :(

--- a/trsr.c
+++ b/trsr.c
@@ -33,7 +33,7 @@ char sides[2]={'h','h'};
 chtype colors[6]={0};
 int beginy,view_len;
 int turn=0;
-void setup_scroll(){
+void setup_scroll(void){
 	beginy=0;
 	if(0<py+3-(LINES-EMPTY_LINES)){
 		beginy=py+3-(LINES-EMPTY_LINES);


### PR DESCRIPTION
Hi @abakh, I'm Jonathan. I've been thinking about making a small terminal game and came across nbsdgames, then got distracted tinkering with it.

## Summary

This is a small cleanup: it fixes `-Wstrict-prototypes` warnings by changing zero-argument function definitions from `foo()` to `foo(void)`.

This does not change behavior; it makes the existing no-argument signatures explicit for C compilers.

## Verification

Tested on macOS arm64 / Apple Clang 15:

- `bmake`
- strict compile loop with `-std=c99 -Wall -Wextra -Wstrict-prototypes -pedantic -fno-common`
- `-Wstrict-prototypes`: 24 -> 0

Tested on Raspberry Pi Zero / Raspbian bullseye armv6l / GCC 10.2.1:

- `bmake`
- same strict compile loop
- `-Wstrict-prototypes`: 24 -> 0

## AI assistance disclosure

This was written with help from Claude, with human review and manual testing.
